### PR TITLE
Use https for the gtsam-1 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,8 +7,8 @@
 [submodule "thirdparty/instant-ngp"]
 	path = thirdparty/instant-ngp
 	url = https://github.com/ToniRV/instant-ngp.git
-  branch = feature/nerf_slam
+	branch = feature/nerf_slam
 [submodule "thirdparty/gtsam"]
 	path = thirdparty/gtsam
-	url = git@github.com:ToniRV/gtsam-1.git
+	url = https://github.com/ToniRV/gtsam-1.git
 	branch = feature/nerf_slam


### PR DESCRIPTION
Switches the gtsam-1 submodule dependency to https to unify with the other submodules, and so checkout "just works" if someone didn't set up their SSH keys. Also fixes minor space<>tab nonuniformity.