### PR TITLE
Fix low PSNR of TSDF fusion module

### DIFF
--- a/fusion/tsdf_fusion.py
+++ b/fusion/tsdf_fusion.py
@@ -456,7 +456,7 @@ class TsdfFusion:
             # Calc metrics
             if evaluate:
                 # Calculate PSNR 
-                rendered_c = rendered_c.as_tensor() / 255.0
+                rendered_c = rendered_c.as_tensor()
                 color = color / 255.0
                 mse = float(compute_error(rendered_c.cpu().numpy(), color.cpu().numpy()))
                 psnr = mse2psnr(mse)


### PR DESCRIPTION
Hi, empirically I found the rendered color by TSDF volume has the range [0,1] instead of [0,255]. Thus the normalization actually leads to very low PSNR.